### PR TITLE
Add measurements and medical actions to the Bethlem myopathy case.

### DIFF
--- a/phenopacketlab-restapi/src/main/resources/examples/phenopackets/bethlem-myopathy.json
+++ b/phenopacketlab-restapi/src/main/resources/examples/phenopackets/bethlem-myopathy.json
@@ -1,5 +1,5 @@
 {
-  "id": "arbitrary proband id",
+  "id": "bethlem-myopathy-phenopacket-id",
   "subject": {
     "id": "proband A",
     "timeAtLastEncounter": {

--- a/phenopacketlab-restapi/src/main/resources/examples/phenopackets/bethlem-myopathy.json
+++ b/phenopacketlab-restapi/src/main/resources/examples/phenopackets/bethlem-myopathy.json
@@ -202,6 +202,32 @@
       }
     }]
   }],
+  "measurements": [{
+    "assay": {
+      "id": "LOINC:2157-6",
+      "label": "Creatine kinase [Enzymatic activity/volume] in Serum or Plasma"
+    },
+    "value": {
+      "quantity": {
+        "unit": {
+          "id": "NCIT:C147130",
+          "label": "Enzyme Unit per Liter"
+        },
+        "value": 420,
+        "referenceRange": {
+          "unit": {
+            "id": "NCIT:C147130",
+            "label": "Enzyme Unit per Liter"
+          },
+          "low": 25.0,
+          "high": 350.0
+        }
+      }
+    },
+    "timeObserved": {
+      "timestamp": "2020-10-01T10:54:20.021Z"
+    }
+  }],
   "interpretations": [{
     "id": "arbitrary interpretation id",
     "progressStatus": "COMPLETED",
@@ -226,6 +252,31 @@
               "label": "heterozygous"
             }
           }
+        }
+      }]
+    }
+  }],
+  "medicalActions": [{
+    "treatment": {
+      "agent": {
+        "id": "CHEBI:41879",
+        "label": "dexamethasone"
+      },
+      "doseIntervals": [{
+        "quantity": {
+          "unit": {
+            "id": "UO:0000022",
+            "label": "milligram"
+          },
+          "value": 6.0
+        },
+        "scheduleFrequency": {
+          "id": "NCIT:C125004",
+          "label": "Once Daily"
+        },
+        "interval": {
+          "start": "2020-10-01T00:00:00Z",
+          "end": "2020-10-31T00:00:00Z"
         }
       }]
     }

--- a/phenopacketlab-restapi/src/main/resources/examples/phenopackets/urothelial-cancer.json
+++ b/phenopacketlab-restapi/src/main/resources/examples/phenopackets/urothelial-cancer.json
@@ -1,5 +1,5 @@
 {
-  "id": "arbitrary.id",
+  "id": "urothelial-cancer-phenopacket-id",
   "subject": {
     "id": "patient1",
     "dateOfBirth": "1964-03-15T00:00:00Z",
@@ -95,7 +95,7 @@
       }
     }
   }, {
-    "id": "bladder biopsy id",
+    "id": "bladder-biopsy-id",
     "individualId": "patient1",
     "sampledTissue": {
       "id": "UBERON_0001256",
@@ -123,7 +123,7 @@
     "files": [{
       "uri": "file://data/genomes/urothelial_ca_wgs.vcf.gz",
       "individualToFileIdentifiers": {
-        "sample1": "BS342730"
+        "bladder-biopsy-id": "BS342730"
       },
       "fileAttributes": {
         "genomeAssembly": "GRCh38",
@@ -132,7 +132,7 @@
       }
     }]
   }, {
-    "id": "pelvic lymph node biosample ID",
+    "id": "pelvic-lymph-node-biosample-ID",
     "individualId": "patient1",
     "sampledTissue": {
       "id": "UBERON:0015876",
@@ -156,7 +156,7 @@
     "files": [{
       "uri": "file://data/genomes/metastasis_wgs.vcf.gz",
       "individualToFileIdentifiers": {
-        "sample5": "BS730275"
+        "pelvic-lymph-node-biosample-ID": "BS730275"
       },
       "fileAttributes": {
         "genomeAssembly": "GRCh38",
@@ -188,7 +188,7 @@
   "files": [{
     "uri": "file://data/genomes/germline_wgs.vcf.gz",
     "individualToFileIdentifiers": {
-      "example case": "NA12345"
+      "patient1": "NA12345"
     },
     "fileAttributes": {
       "genomeAssembly": "GRCh38",


### PR DESCRIPTION
Fixes #47 

The PR adds `measurement` and `medicalAction` components into the phenopacket representing Bethlem myopathy case report.

Now, the pair of *Bethlem myopathy* and *Urothelial cancer* provide real-life examples of all phenopacket building blocks:
- `id`: BM & UC
- `subject`: BM & UC
- `phenotypicFeatures`: BM & UC
- `measurements`: BM
- `biosamples`: UC
- `interpretations`: BM & UC
- `diseases`: UC
- `medicalActions`: BM
- `files`: UC
- `metaData`: BM & UC

