### PR TITLE
Setup Github actions CI.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,34 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, development ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    env:
+      JDK_VERSION: ${{ matrix.jdk }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macOS-latest, ubuntu-latest ]
+        jdk: [ 17 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Build with Maven
+        run: ./mvnw --projects phenopacketlab-restapi --also-make --batch-mode verify

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PhenopacketLab
 
+[![Java CI with Maven](https://github.com/TheJacksonLaboratory/PhenopacketLab/workflows/Java%20CI%20with%20Maven/badge.svg)](https://github.com/TheJacksonLaboratory/PhenopacketLab/actions/workflows/maven.yml)
+
 This Maven project is a test project to show how an Angular/Springboot application can provide UIs that could be used for the Phenopacket software. The project is made of an Angular part (Frontend) and a Java Spring Boot part (`phenopacketlab-restapi`). 
 
 The project can be deployed in  multiple ways: 


### PR DESCRIPTION
Address #9 

The small PR adds Github Action that builds the backend modules up to `phenopacketlab-restapi` when new code is pushed on `master` or when a PR is open against `master` or `development`.

The build uses Maven wrapper to run build up to the `verify` lifecycle phase using Java 17 on the 3 major environments: *Windows*, *MacOS*, and *Ubuntu*.