### PR TITLE
Require Java 17 for building backend modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 


### PR DESCRIPTION
Address #55 

The PR sets the `java.version=17` in the top-level `pom.xml`, to effectively require Java 17 or better to build & run the backend modules. 

The information regarding how to check and use Java 17 cannot be added into `README.md` right now. The PR depends on #23 . To prevent pointless conflict between changes of this PR and updates in `README.md` done in #23, we'll wait until #23 is merged.