### PR TITLE
Add function for creating ontology subtree.

### DIFF
--- a/phenopacketlab-core/src/main/java/module-info.java
+++ b/phenopacketlab-core/src/main/java/module-info.java
@@ -10,4 +10,5 @@ module phenopacketlab.core {
     exports org.monarchinitiative.phenopacketlab.core;
     exports org.monarchinitiative.phenopacketlab.core.disease;
     exports org.monarchinitiative.phenopacketlab.core.ontology;
+    exports org.monarchinitiative.phenopacketlab.core.subtree to phenopacketlab.restapi;
 }

--- a/phenopacketlab-core/src/main/java/org/monarchinitiative/phenopacketlab/core/subtree/CreateSubtree.java
+++ b/phenopacketlab-core/src/main/java/org/monarchinitiative/phenopacketlab/core/subtree/CreateSubtree.java
@@ -1,0 +1,39 @@
+package org.monarchinitiative.phenopacketlab.core.subtree;
+
+import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.Term;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.Set;
+
+public class CreateSubtree {
+
+    private CreateSubtree() {
+    }
+
+    /**
+     * Create a subtree with given {@code root} from an {@code ontology}.
+     */
+    public static SubtreeNode createSubtree(TermId root, Ontology ontology) {
+        Term rootTerm = ontology.getTermMap().get(root);
+        if (rootTerm == null)
+            throw new IllegalArgumentException("Root %s not found in ontology".formatted(root.getValue()));
+
+        SubtreeNode node = new SubtreeNode(root.getValue(), rootTerm.getName());
+        return augmentWithChildren(ontology, root, node);
+    }
+
+    private static SubtreeNode augmentWithChildren(Ontology ontology, TermId termId, SubtreeNode node) {
+        Set<TermId> childTerms = OntologyAlgorithm.getChildTerms(ontology, termId, false);
+
+        for (TermId childTermId : childTerms) {
+            Term term = ontology.getTermMap().get(childTermId);
+            SubtreeNode childNode = new SubtreeNode(childTermId.getValue(), term.getName());
+            node.getChildren().add(childNode);
+            augmentWithChildren(ontology, childTermId, childNode);
+        }
+
+        return node;
+    }
+}

--- a/phenopacketlab-core/src/main/java/org/monarchinitiative/phenopacketlab/core/subtree/SubtreeNode.java
+++ b/phenopacketlab-core/src/main/java/org/monarchinitiative/phenopacketlab/core/subtree/SubtreeNode.java
@@ -1,0 +1,59 @@
+package org.monarchinitiative.phenopacketlab.core.subtree;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * A node of an ontology subtree. The node has the following attributes:
+ * <ul>
+ *     <li><em>key</em> - CURIE of the term, e.g. HP:1234567</li>
+ *     <li><em>label</em> - term name, e.g. Hypertension</li>
+ *     <li><em>children</em> - a list of node's child terms (empty for a leaf node)</li>
+ * </ul>
+ */
+public class SubtreeNode {
+
+    private final String key, label;
+    private final List<SubtreeNode> children = new ArrayList<>();
+
+    public SubtreeNode(String key, String label) {
+        this.key = key;
+        this.label = label;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public List<SubtreeNode> getChildren() {
+        return children;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SubtreeNode that = (SubtreeNode) o;
+        return Objects.equals(key, that.key) && Objects.equals(label, that.label) && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, label, children);
+    }
+
+    @Override
+    public String toString() {
+        return "SubtreeNode{" +
+                "key='" + key + '\'' +
+                ", label='" + label + '\'' +
+                ", children=" + children +
+                '}';
+    }
+}

--- a/phenopacketlab-core/src/test/java/org/monarchinitiative/phenopacketlab/core/subtree/CreateSubtreeTest.java
+++ b/phenopacketlab-core/src/test/java/org/monarchinitiative/phenopacketlab/core/subtree/CreateSubtreeTest.java
@@ -1,0 +1,41 @@
+package org.monarchinitiative.phenopacketlab.core.subtree;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.monarchinitiative.phenol.io.OntologyLoader;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenopacketlab.core.TestUtils;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class CreateSubtreeTest {
+
+    private static final Path TOY_HPO_PATH = TestUtils.PHENOPACKET_LAB_CORE_TEST_DIR.resolve("ontology/hpo_toy.json");
+
+    private static Ontology HPO;
+
+    @BeforeAll
+    public static void beforeAll() {
+        HPO = OntologyLoader.loadOntology(TOY_HPO_PATH.toFile());
+    }
+
+
+    @Test
+    public void createSubtree() {
+        TermId onset = TermId.of("HP:0003674");
+        SubtreeNode root = CreateSubtree.createSubtree(onset, HPO);
+
+        assertThat(root.getKey(), equalTo(onset.getValue()));
+        assertThat(root.getLabel(), equalTo("Onset"));
+        assertThat(root.getChildren(), hasSize(6));
+        assertThat(root.getChildren().stream()
+                .map(SubtreeNode::getLabel)
+                .toList(),
+                hasItems("Antenatal onset", "Adult onset", "Congenital onset",
+                        "Neonatal onset", "Puerpural onset", "Pediatric onset"));
+    }
+}


### PR DESCRIPTION
Starting from a `TermId` and an ontology, the `CreateSubtree.createSubtree()` function extracts an ontology subtree where the term ID is the root. 

E.g. 

```
Ontology HPO = ...; // get the ontology from somewhere
TermId onset = TermId.of("HP:0003674");
SubtreeNode root = CreateSubtree.createSubtree(onset, HPO);
```

The `SubtreeNode` is a POJO that should work well with Jackson and be seamlessly mapped to a JSON object.