### PR TITLE
Set up distribution of the restapi as a ZIP file.

### DIFF
--- a/phenopacketlab-restapi/pom.xml
+++ b/phenopacketlab-restapi/pom.xml
@@ -68,18 +68,61 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--add-exports phenopacketlab.core/org.monarchinitiative.phenopacketlab.core.miner=ALL-UNNAMED</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
+
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-dependencies</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <includeScope>compile</includeScope>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.monarchinitiative.phenopacketlab.restapi.Application</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assemble/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/phenopacketlab-restapi/src/assemble/distribution.xml
+++ b/phenopacketlab-restapi/src/assemble/distribution.xml
@@ -1,0 +1,45 @@
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <!-- The driver JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./lib</outputDirectory>
+            <includes>
+                <include>phenopacketlab-restapi-${project.version}.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Java dependency JARs -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>lib/</include>
+            </includes>
+        </fileSet>
+        <!-- Launch script -->
+        <fileSet>
+            <directory>${project.basedir}/src/assemble</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>launch.sh</include>
+            </includes>
+        </fileSet>
+        <!-- Metadata -->
+        <fileSet>
+            <directory>${project.parent.basedir}</directory>
+            <outputDirectory>./</outputDirectory>
+            <filtered>true</filtered>
+            <includes>
+                <include>README.md</include>
+                <include>LICENSE</include>
+<!--                <include>CHANGELOG.md</include>-->
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/phenopacketlab-restapi/src/assemble/launch.sh
+++ b/phenopacketlab-restapi/src/assemble/launch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Run the app in the following
+
+# Path to phenopacket data directory prepared by the ingest module and the `scripts/preprocess-ontologies.sh`.
+DATA_DIRECTORY=path/to/data/di
+# The app's profile.
+PROFILE=development
+
+java -Dspring.profiles.active=${PROFILE} \
+-Dphenopacketlab.data-directory=${DATA_DIRECTORY} \
+-classpath "lib/*" org.monarchinitiative.phenopacketlab.restapi.Application


### PR DESCRIPTION
Distribute the REST API as a self-contained ZIP file. The ZIP contains the app, all dependencies, and a launcher script. The launcher needs to be edited to select run profile and the data directory, and as of now serves as an example for running the app from CLI, as opposed to running from IDE.