### PR TITLE
Setup documetation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,71 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy documentation
+
+on:
+  # Runs on pushes targeting the master and develop branches
+  push:
+    branches: [ master, development, sqa ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          ref: master
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install sphinx sphinx-rtd-theme
+
+      - name: Build documentation
+        run: |
+          ## Init the target folder. 
+          # We will put all site documentation there.
+          mkdir -p gh-pages
+          touch gh-pages/.nojekyll
+          
+          function build_docs {
+            # The function will checkout a branch and build the Javadoc & documentation 
+            # into provided documentation directory.
+            BRANCH=${1}
+            DOCDIR=${2}
+          
+            git checkout ${BRANCH}
+            git fetch
+            git pull
+            ## Init the target folder.
+            # We will put all site documentation there.
+            mkdir -p gh-pages/${DOCDIR}
+          
+            ## Build the docs
+            # Generate the HTML pages and move the generated content into the target folder.
+            printf "Building the %s documentation\n" ${DOCDIR}
+            cd docs
+            make html
+            mv _build/html/* ../gh-pages/${DOCDIR}
+          }
+          
+          # TODO - enable once we hit master and sqa.
+          ## We store the docs for `master` in `stable` folder
+          #build_docs master stable
+          ## We store the docs for `sqa` in `sqa` folder
+          #build_docs sqa sqa
+          # We store the docs for `development` in `dev` folder
+          build_docs development dev
+
+
+      - name: Deploy documentation
+        if: ${{ github.event_name == 'push' }}
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          folder: gh-pages
+          force: false

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Thumbs.db
 /bin/
 /lib/
 /node/
+
+# Documentation
+docs/_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,28 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Phenopacket Lab'
+copyright = '2023, Baha El Kassaby, Daniel Danis, Michael Gargano, Peter Robinson'
+author = 'Baha El Kassaby, Daniel Danis, Michael Gargano, Peter Robinson'
+release = '1.0.0-alpha'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ['_static']
+html_css_files = ['phenopacket-lab.css']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to Phenopacket Lab's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
Setup Sphinx documentation and a Github action for deploying the docs to Github IO.

@desais-jax please see the `docs/index.rst` - the documentation entry point.

We usually set up 2 documentation branches - *stable* and *latest* (See e.g. [LIRICAL readme](https://github.com/TheJacksonLaboratory/LIRICAL)). However, in our case, it is probably better to have 3: *production*, *sqa*, and *dev*. I already have some setup for that and we can discuss this in greater detail at some point. However, right now it probably makes more sense to just test this out..

